### PR TITLE
Retry on network failures and implement exponential backoff

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -142,7 +142,7 @@ async function fetchConversation(token, id, maxAttempts = 3, attempt = 1) {
       throw new Error(`Failed to fetch conversation after ${maxAttempts} attempts.`);
     } else {
       var backoff = INITIAL_BACKOFF * Math.pow(BACKOFF_MULTIPLIER, attempt);
-      console.log("Error. Retrying in ${backoff}ms.");
+      console.log(`Error. Retrying in ${backoff}ms.`);
       await sleep(backoff);
       return fetchConversation(token, id, maxAttempts, attempt + 1);
     }

--- a/backup.js
+++ b/backup.js
@@ -119,26 +119,34 @@ async function getConversationIds(token, offset = 0) {
 }
 
 async function fetchConversation(token, id, maxAttempts = 3, attempt = 1) {
-  const res = await fetch(
-    `https://chat.openai.com/backend-api/conversation/${id}`,
-    {
-      headers: {
-        authorization: `Bearer ${token}`,
+  const INITIAL_BACKOFF = 10000;
+  const BACKOFF_MULTIPLIER = 2;
+  try {
+    const res = await fetch(
+      `https://chat.openai.com/backend-api/conversation/${id}`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
       },
-    },
-  );
+    );
+    
+    if (!res.ok) {
+      throw new Error('Unsuccessful response');
+    }
 
-  if (!res.ok) {
-    const exceeded = attempt >= maxAttempts;
-    if (res.status === 429 && !exceeded) {
-      await sleep(30000);
-      return fetchConversation(token, id, maxAttempts, attempt + 1);
+    return res.json();
+
+  } catch (error) {
+    if (attempt >= maxAttempts) {
+      throw new Error(`Failed to fetch conversation after ${maxAttempts} attempts.`);
     } else {
-      throw new Error('failed to fetch conversation');
+      var backoff = INITIAL_BACKOFF * Math.pow(BACKOFF_MULTIPLIER, attempt);
+      console.log("Error. Retrying in ${backoff}ms.");
+      await sleep(backoff);
+      return fetchConversation(token, id, maxAttempts, attempt + 1);
     }
   }
-
-  return res.json();
 }
 
 async function getAllConversations(startOffset, stopOffset) {


### PR DESCRIPTION
This commit introduces a retry mechanism in the fetchConversation function to handle network failures when fetching conversations. Previously it only retried on specific server errors, but I had difficulty backing up accounts with large numbers of messages as I would eventually hit a network failure. Previously it only retried on rate limiting errors (429).

The commit adds an exponential backoff instead of defaulting to a linear 30s backoff.