### PR TITLE
Target domain updated.

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -87,7 +87,7 @@ function downloadJson(data) {
 }
 
 async function loadToken() {
-  const res = await fetch('https://chat.openai.com/api/auth/session');
+  const res = await fetch('https://chatgpt.com/api/auth/session');
 
   if (!res.ok) {
     throw new Error('failed to fetch token');
@@ -99,7 +99,7 @@ async function loadToken() {
 
 async function getConversationIds(token, offset = 0) {
   const res = await fetch(
-    `https://chat.openai.com/backend-api/conversations?offset=${offset}&limit=20`,
+    `https://chatgpt.com/backend-api/conversations?offset=${offset}&limit=20`,
     {
       headers: {
         authorization: `Bearer ${token}`,
@@ -123,7 +123,7 @@ async function fetchConversation(token, id, maxAttempts = 3, attempt = 1) {
   const BACKOFF_MULTIPLIER = 2;
   try {
     const res = await fetch(
-      `https://chat.openai.com/backend-api/conversation/${id}`,
+      `https://chatgpt.com/backend-api/conversation/${id}`,
       {
         headers: {
           authorization: `Bearer ${token}`,


### PR DESCRIPTION
The old domain, "chat.openai.com", was returning bad requests. As a result, I have switched to the new domain, "chatgpt.com".